### PR TITLE
Erro gerado ao tentar criar um container conforme descrito na aula 9 do dia 3. Habilitei a propriedade que gera o uber-jar.

### DIFF
--- a/src/demo-multiverse/src/main/resources/application.properties
+++ b/src/demo-multiverse/src/main/resources/application.properties
@@ -22,7 +22,7 @@ quarkus.banner.enabled=false
 quarkus.devservices.enabled=false
 
 # Packaging
-# quarkus.package.type=uber-jar
+quarkus.package.type=uber-jar
 
 # Provides a default JPA Datasource
 quarkus.datasource.db-kind=h2


### PR DESCRIPTION
Erro gerado ao tentar criar um container conforme descrito na aula 9 do dia 3. Habilitei a propriedade que gera o uber-jar. Assim o jar é gerado conforme o entrypoint do Docker file.